### PR TITLE
Avoid double definition in case of multiple includes.

### DIFF
--- a/Modelica/Resources/C-Sources/ModelicaFFT.h
+++ b/Modelica/Resources/C-Sources/ModelicaFFT.h
@@ -56,12 +56,15 @@
  *
  * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
  */
+#undef MODELICA_NONNULLATTR
 #if defined(__GNUC__)
 #define MODELICA_NONNULLATTR __attribute__((nonnull))
 #else
 #define MODELICA_NONNULLATTR
 #endif
 #if !defined(__ATTR_SAL)
+#undef _In_
+#undef _Out_
 #define _In_
 #define _Out_
 #endif

--- a/Modelica/Resources/C-Sources/ModelicaIO.h
+++ b/Modelica/Resources/C-Sources/ModelicaIO.h
@@ -66,12 +66,17 @@
  *
  * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
  */
+#undef MODELICA_NONNULLATTR
 #if defined(__GNUC__)
 #define MODELICA_NONNULLATTR __attribute__((nonnull))
 #else
 #define MODELICA_NONNULLATTR
 #endif
 #if !defined(__ATTR_SAL)
+#undef _In_
+#undef _In_z_
+#undef _Inout_
+#undef _Out_
 #define _In_
 #define _In_z_
 #define _Inout_

--- a/Modelica/Resources/C-Sources/ModelicaInternal.h
+++ b/Modelica/Resources/C-Sources/ModelicaInternal.h
@@ -60,6 +60,8 @@
  *
  * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
  */
+#undef MODELICA_NONNULLATTR
+#undef MODELICA_RETURNNONNULLATTR
 #if defined(__GNUC__)
 #define MODELICA_NONNULLATTR __attribute__((nonnull))
 #if defined(__GNUC_MINOR__) && (__GNUC__ > 3 && __GNUC_MINOR__ > 8)
@@ -75,6 +77,9 @@
 #define MODELICA_RETURNNONNULLATTR
 #endif
 #if !defined(__ATTR_SAL)
+#undef _In_z_
+#undef _Out_
+#undef _Ret_z_
 #define _In_z_
 #define _Out_
 #define _Ret_z_

--- a/Modelica/Resources/C-Sources/ModelicaRandom.h
+++ b/Modelica/Resources/C-Sources/ModelicaRandom.h
@@ -56,12 +56,15 @@
  *
  * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
  */
+#undef MODELICA_NONNULLATTR
 #if defined(__GNUC__)
 #define MODELICA_NONNULLATTR __attribute__((nonnull))
 #else
 #define MODELICA_NONNULLATTR
 #endif
 #if !defined(__ATTR_SAL)
+#undef _In_
+#undef _Out_
 #define _In_
 #define _Out_
 #endif

--- a/Modelica/Resources/C-Sources/ModelicaStandardTables.h
+++ b/Modelica/Resources/C-Sources/ModelicaStandardTables.h
@@ -112,12 +112,16 @@
  *
  * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
  */
+#undef MODELICA_NONNULLATTR
 #if defined(__GNUC__)
 #define MODELICA_NONNULLATTR __attribute__((nonnull))
 #else
 #define MODELICA_NONNULLATTR
 #endif
 #if !defined(__ATTR_SAL)
+#undef _In_
+#undef _In_z_
+#undef _Inout_
 #define _In_
 #define _In_z_
 #define _Inout_

--- a/Modelica/Resources/C-Sources/ModelicaStrings.h
+++ b/Modelica/Resources/C-Sources/ModelicaStrings.h
@@ -58,6 +58,8 @@
  *
  * The following macros handle nonnull attributes for GNU C and Microsoft SAL.
  */
+#undef MODELICA_NONNULLATTR
+#undef MODELICA_RETURNNONNULLATTR
 #if defined(__GNUC__)
 #define MODELICA_NONNULLATTR __attribute__((nonnull))
 #if defined(__GNUC_MINOR__) && (__GNUC__ > 3 && __GNUC_MINOR__ > 8)
@@ -73,6 +75,9 @@
 #define MODELICA_RETURNNONNULLATTR
 #endif
 #if !defined(__ATTR_SAL)
+#undef _In_z_
+#undef _Out_
+#undef _Ret_z_
 #define _In_z_
 #define _Out_
 #define _Ret_z_

--- a/Modelica/Resources/C-Sources/ModelicaUtilities.h
+++ b/Modelica/Resources/C-Sources/ModelicaUtilities.h
@@ -60,7 +60,8 @@ extern "C" {
   C11/C++11 standard with fallback to GNU, Clang or MSVC extensions if using
   an older compiler.
 */
-
+#undef MODELICA_NORETURN
+#undef MODELICA_NORETURNATTR
 #if __STDC_VERSION__ >= 201112L
 #define MODELICA_NORETURN _Noreturn
 #define MODELICA_NORETURNATTR


### PR DESCRIPTION
Having a guard around them would be another possibility, but it seemed messier.