### PR TITLE
Proposed change of the conversion script

### DIFF
--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -1814,21 +1814,11 @@ convertElement("Modelica.Magnetic.FundamentalWave.BasicMachines.Components.Singl
                 {"reluctance"}, {"stray"})
 convertElement("Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_ElectricalExcited",
                 {"excitation.reluctance"}, {"excitation.stray"})
-convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding",
-                "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding"},
-                "strayReluctance", "stray")
 
-convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.InductionMachines.IM_SlipRing"},
-                "rotor.strayReluctance", "rotor.stray")
-convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.InductionMachines.IM_SlipRing",
-                "Modelica.Magnetic.FundamentalWave.BasicMachines.InductionMachines.IM_SquirrelCage",
-                "Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousMachines.SM_ElectricalExcited",
-                "Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousMachines.SM_PermanentMagnet",
-                "Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousMachines.SM_ReluctanceRotor"},
-                "stator.strayReluctance", "stator.stray")
 convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.AsynchronousInductionMachines.AIM_SlipRing"},
                 "rotor.strayReluctance", "rotor.stray")
-convertElement({"Modelica.Magnetic.FundamentalWave.Interfaces.PartialBasicInductionMachine",
+convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding",
+                "Modelica.Magnetic.FundamentalWave.Interfaces.PartialBasicInductionMachine",
                 "Modelica.Magnetic.FundamentalWave.BasicMachines.AsynchronousInductionMachines.AIM_SlipRing",
                 "Modelica.Magnetic.FundamentalWave.BasicMachines.AsynchronousInductionMachines.AIM_SquirrelCage",
                 "Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_ElectricalExcited",
@@ -1837,7 +1827,8 @@ convertElement({"Modelica.Magnetic.FundamentalWave.Interfaces.PartialBasicInduct
                 "stator.strayReluctance", "stator.stray")
 convertElement("Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMachines.IM_SlipRing",
                 "rotor.strayReluctance", "rotor.stray")
-convertElement({"Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.BaseClasses.PartialBasicMachine",
+convertElement({"Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding",
+                "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.BaseClasses.PartialBasicMachine",
                 "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMachines.IM_SlipRing",
                 "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMachines.IM_SquirrelCage",
                 "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.SynchronousMachines.SM_ElectricalExcited",

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -1810,24 +1810,24 @@ convertClass("Modelica.Electrical.Analog.Ideal.IdealCommutingSwitch",
              "Modelica.Electrical.Analog.Ideal.IdealTwoWaySwitch")
 convertClass("Modelica.Electrical.Analog.Ideal.ControlledIdealCommutingSwitch",
              "Modelica.Electrical.Analog.Ideal.ControlledIdealTwoWaySwitch")
+
 convertElement("Modelica.Magnetic.FundamentalWave.BasicMachines.Components.SinglePhaseWinding",
                 {"reluctance"}, {"stray"})
-convertElement("Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_ElectricalExcited",
+convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_ElectricalExcited",
+                "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.SynchronousMachines.SM_ElectricalExcited"},
                 {"excitation.reluctance"}, {"excitation.stray"})
-
-convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.AsynchronousInductionMachines.AIM_SlipRing"},
-                "rotor.strayReluctance", "rotor.stray")
 convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding",
-                "Modelica.Magnetic.FundamentalWave.Interfaces.PartialBasicInductionMachine",
+                "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding"},
+                "strayReluctance", "stray")
+convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.AsynchronousInductionMachines.AIM_SlipRing",
+                "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMachines.IM_SlipRing"},
+                "rotor.strayReluctance", "rotor.stray")
+convertElement({"Modelica.Magnetic.FundamentalWave.Interfaces.PartialBasicInductionMachine",
                 "Modelica.Magnetic.FundamentalWave.BasicMachines.AsynchronousInductionMachines.AIM_SlipRing",
                 "Modelica.Magnetic.FundamentalWave.BasicMachines.AsynchronousInductionMachines.AIM_SquirrelCage",
                 "Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_ElectricalExcited",
                 "Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_PermanentMagnet",
-                "Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_ReluctanceRotor"},
-                "stator.strayReluctance", "stator.stray")
-convertElement("Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMachines.IM_SlipRing",
-                "rotor.strayReluctance", "rotor.stray")
-convertElement({"Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding",
+                "Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_ReluctanceRotor",
                 "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.BaseClasses.PartialBasicMachine",
                 "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMachines.IM_SlipRing",
                 "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.InductionMachines.IM_SquirrelCage",

--- a/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
+++ b/Modelica/Resources/Scripts/Conversion/ConvertModelica_from_3.2.3_to_4.0.0.mos
@@ -1815,7 +1815,7 @@ convertElement("Modelica.Magnetic.FundamentalWave.BasicMachines.Components.Singl
                 {"reluctance"}, {"stray"})
 convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.SynchronousInductionMachines.SM_ElectricalExcited",
                 "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.SynchronousMachines.SM_ElectricalExcited"},
-                {"excitation.reluctance"}, {"excitation.stray"})
+                "excitation.reluctance", "excitation.stray")
 convertElement({"Modelica.Magnetic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding",
                 "Modelica.Magnetic.QuasiStatic.FundamentalWave.BasicMachines.Components.SymmetricMultiPhaseWinding"},
                 "strayReluctance", "stray")


### PR DESCRIPTION
If I understand the conversion script correctly, then `convertElement` applies to the old (MSL 3.2.3) classes. If this is the case, my proposal 

- removes `convertElement` applied to the new (MSL 4.0.0) classes,
- summarize the conversion of `stator.strayReluctance` to `stator.stray` for all affected classes.

I created this PR into your @beutlich's repository in order to avoid confusion in case you disagree with my proposal
